### PR TITLE
Updated to use Ubuntu 21.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@ Using Podman to build a document in the current directory:
 
 Once inside the container, run the following commands to build the document:
 
-    cd /document
     make clean
     make biblio
     make forcetex

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 Docker container to build [IvoaTex](http://www.ivoa.net/documents/Notes/IVOATex/index.html) documents.
 
 We recommend you use [Podman](https://podman.io/) to run IvoaTex as a [rootless-container](https://github.com/containers/podman#rootless).
-
-The advantage is that any user inside the container will map to your user uid on the host, avoiding problems with file ownership.
+The advantage is that any user inside the container will map to your `uid` on the host, avoiding problems with file ownership.
 
 Using Podman to build a document in the current directory:
 

--- a/README.md
+++ b/README.md
@@ -1,19 +1,36 @@
 # ivoatex
 Docker container to build [IvoaTex](http://www.ivoa.net/documents/Notes/IVOATex/index.html) documents.
 
-Run the container in the target document directory:
+We recommend you use [Podman](https://podman.io/) to run IvoaTex as a [rootless-container](https://github.com/containers/podman#rootless).
+
+The advantage is that any user inside the container will map to your user uid on the host, avoiding problems with file ownership.
+
+Using Podman to build a document in the current directory:
+
+    DOC_PATH=$(pwd)
+
+    podman run \
+        --rm \
+        --tty \
+        --interactive \
+        --volume "${DOC_PATH:?}:/document:rw,Z" \
+        ivoa/ivoatex:latest
+
+Once inside the container, run the following commands to build the document:
+
+    cd /document
+    make clean
+    make biblio
+    make forcetex
+
+
+To do the same with Docker you need to specify the user `uid` and `gid` so that the resulting document owned by your account rather than by root.
 
     docker run \
         --rm  \
         --tty \
         --interactive \
         --user "$(id -u):$(id -g)" \
-        --volume "$(pwd):/texdata" \
-        ivoa/ivoatex:1.2
-
-Run make inside the container to build the document:
-
-    make clean
-    make biblio
-    make
+        --volume "${DOC_PATH:?}:/document:rw,Z" \
+        ivoa/ivoatex:latest
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 Docker container to build [IvoaTex](http://www.ivoa.net/documents/Notes/IVOATex/index.html) documents.
 
 We recommend you use [Podman](https://podman.io/) to run IvoaTex as a [rootless-container](https://github.com/containers/podman#rootless).
-The advantage is that any user inside the container will map to your `uid` on the host, avoiding problems with file ownership.
+The advantage is that the user inside the container is automatically mapped to your `uid` on the host, avoiding problems with file ownership.
 
 Using Podman to build a document in the current directory:
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,9 +21,7 @@
 
 #
 # Docker container to run the IvoaTex build environment.
-
 ARG osversion
-
 FROM ${osversion}
 MAINTAINER Dave Morris <docker-admin@metagrid.co.uk>
 
@@ -33,14 +31,15 @@ ARG buildtime
 LABEL maintainer="Dave Morris <docker-admin@metagrid.co.uk>"
 LABEL builddate="${builddate}"
 LABEL buildtime="${buildtime}"
-LABEL gitrepo="https://github.com/ivoa/ivoa"
+LABEL gitrepo="https://github.com/ivoa/ivoatex-docker"
 
 #
 # Disable interactive install.
 ENV DEBIAN_FRONTEND noninteractive
 
-RUN apt-get update
-RUN apt-get install -y \
+#
+# Install LaTex tools.
+RUN apt-get update && apt-get -yq install
         texlive-latex-extra \
         texlive-bibtex-extra \
         build-essential \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -12,7 +12,7 @@
 #     but WITHOUT ANY WARRANTY; without even the implied warranty of
 #     MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
 #     GNU General Public License for more details.
-#  
+#
 #     You should have received a copy of the GNU General Public License
 #     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 #   </meta:licence>
@@ -20,47 +20,40 @@
 #
 
 #
-# Docker container to run the IvoaTex build environment. 
-FROM debian:stretch-slim
+# Docker container to run the IvoaTex build environment.
+
+ARG osversion
+
+FROM ${osversion}
 MAINTAINER Dave Morris <docker-admin@metagrid.co.uk>
+
+ARG builddate
+ARG buildtime
+
+LABEL maintainer="Dave Morris <docker-admin@metagrid.co.uk>"
+LABEL builddate="${builddate}"
+LABEL buildtime="${buildtime}"
+LABEL gitrepo="https://github.com/ivoa/ivoa"
 
 #
 # Disable interactive install.
 ENV DEBIAN_FRONTEND noninteractive
 
-#
-# Install generic dev tools.
-RUN apt-get update && apt-get -yq install \
-    zip \
-    make
-
-#
-# Install C compiler.
-RUN apt-get update && apt-get -yq install \
-    gcc \
-    libc-dev
-
-#
-# Install XML/HTML tools
-RUN apt-get update && apt-get -yq install \
-    xsltproc \
-    libxml2-utils \
-    imagemagick \
-    ghostscript
-
-#
-# Install LaTex tools.
-RUN apt-get update && apt-get -yq install \
-    texlive-latex-base \
-    texlive-latex-extra \
-    texlive-bibtex-extra \
-    texlive-fonts-recommended \
-    latex-xcolor \
-    cm-super
+RUN apt-get update
+RUN apt-get install -y \
+        texlive-latex-extra \
+        texlive-bibtex-extra \
+        build-essential \
+        librsvg2-bin \
+        imagemagick \
+        ghostscript \
+        xsltproc \
+        cm-super \
+        zip
 
 #
 # Label working directory as a data volume.
-VOLUME  /texdata
-WORKDIR /texdata
+VOLUME  /document
+WORKDIR /document
 
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -21,8 +21,7 @@
 
 #
 # Docker container to run the IvoaTex build environment.
-ARG osversion
-FROM ${osversion}
+FROM docker.io/library/ubuntu:21.10
 MAINTAINER Dave Morris <docker-admin@metagrid.co.uk>
 
 ARG builddate
@@ -39,7 +38,7 @@ ENV DEBIAN_FRONTEND noninteractive
 
 #
 # Install LaTex tools.
-RUN apt-get update && apt-get -yq install
+RUN apt-get update && apt-get -yq install \
         texlive-latex-extra \
         texlive-bibtex-extra \
         build-essential \


### PR DESCRIPTION
Changes to the Docker file to bring it up to date with Ubuntu 21.10 and the latest install instructions from the IVOA ivoatex project.
Changes to the README to recommend Podman rather than Docker.