### PR TITLE
Made convert pdf work

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -58,6 +58,7 @@ RUN apt-get update && apt-get -yq install \
     pdftk \
     pdf2svg \
     python-is-python3 \
+    python3-requests \
     texlive-latex-extra \
     texlive-bibtex-extra \
     vim \

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -61,8 +61,13 @@ RUN apt-get update && apt-get -yq install \
     texlive-latex-extra \
     texlive-bibtex-extra \
     vim \
+    imagemagick \
     xsltproc \
     zip
+
+# At the time of this writing (25-08-2025), PDF converts were not allowed by default at install time due
+# to old ghostscript vulnerabilities. This might change in the future. The line below overrides this policy.
+RUN sed -i 's/rights="none" pattern="PDF"/rights="read|write" pattern="PDF"/' /etc/ImageMagick-*/policy.xml
 
 #
 # Label working directory as a data volume.


### PR DESCRIPTION
Solution or #26 

Implements the workaround described here: https://kbseah.wordpress.com/2019/11/24/enabling-pdf-conversion-on-imagemagick/

Not ideal since `policy.xml` is an install configuration that might change in the future but alternatives seem too complicated for a hopefully temporary problem.